### PR TITLE
change filter to cover all required products

### DIFF
--- a/.byebug_history
+++ b/.byebug_history
@@ -1,0 +1,3 @@
+exit
+:source_name
+source_name

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,7 +22,7 @@ GIT
 PATH
   remote: .
   specs:
-    sampatrianon (0.2.5)
+    sampatrianon (0.2.4)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/sampatrianon.rb
+++ b/lib/sampatrianon.rb
@@ -22,7 +22,7 @@ module Sampatrianon
         "#{source_name} - Peugeot Expert"
       elsif product_name.downcase.include?('partner')
         "#{source_name} - Peugeot Partner"
-      elsif product_name.downcase.include?('new e208 gt')
+      elsif product_name.downcase.include?('new e') && source_name.downcase.include?('grow')
         "#{source_name} - E208GT"
       else
         lead.source.name

--- a/spec/hooks_spec.rb
+++ b/spec/hooks_spec.rb
@@ -62,8 +62,9 @@ RSpec.describe F1SalesCustom::Hooks::Lead do
   end
 
   context 'when source name is Grow' do
+    let(:source_name) { 'Grow - TORIBA GASTÃO VIDIGAL' }
+
     context 'when product name contains New E208 GT' do
-      let(:source_name) { 'Grow - TORIBA GASTÃO VIDIGAL' }
       let(:product_name) { 'NEW E208 GT' }
 
       it 'return source name' do
@@ -72,9 +73,33 @@ RSpec.describe F1SalesCustom::Hooks::Lead do
     end
 
     context 'when product name contains New E208 GT' do
-      let(:source_name) { 'Grow - TORIBA GASTÃO VIDIGAL' }
-      let(:product_name) { nil }
+      let(:product_name) { 'NEW E-208 GT 21/22' }
 
+      it 'return source name' do
+        expect(described_class.switch_source(lead)).to eq('Grow - TORIBA GASTÃO VIDIGAL - E208GT')
+      end
+    end
+
+    context 'when product name contains New E208 GT' do
+      let(:product_name) { 'NEW E-208 Gt' }
+
+      it 'return source name' do
+        expect(described_class.switch_source(lead)).to eq('Grow - TORIBA GASTÃO VIDIGAL - E208GT')
+      end
+    end
+
+    context 'when product name contains New E208 GT' do
+      let(:product_name) { 'NEW E-208 Gt' }
+      let(:source_name) { 'Webmotors - Novos' }
+
+      it 'return source name' do
+        expect(described_class.switch_source(lead)).to eq('Webmotors - Novos')
+      end
+    end
+
+    context 'when product name contains New E208 GT' do
+      let(:product_name) { nil }
+      
       it 'return source name' do
         expect(described_class.switch_source(lead)).to eq('Grow - TORIBA GASTÃO VIDIGAL')
       end


### PR DESCRIPTION
The last code didn't cover the NEW E-208 GT product, it only covered the NEW E 208 GT, without - (menus sign). 

The Ticket also specified that only Grow leads should be changed.